### PR TITLE
[Feat] Add workflow and manifests for EC2 upload deployment

### DIFF
--- a/.github/workflows/deploy-upload.yml
+++ b/.github/workflows/deploy-upload.yml
@@ -1,0 +1,54 @@
+name: Deploy Upload to EC2
+
+on:
+  push:
+    branches:
+      - main
+  repository_dispatch:
+    types: [deploy-upload]
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Set up SSH key
+        uses: webfactory/ssh-agent@v0.8.0
+        with:
+          ssh-private-key: ${{ secrets.EC2_SSH_KEY }}
+
+      - name: Generate env config file (upload-env.yaml)
+        run: |
+          cat <<EOF > upload-env.yaml
+          apiVersion: v1
+          kind: ConfigMap
+          metadata:
+            name: upload-env
+          data:
+            DB_HOST: "${{ secrets.DB_HOST }}"
+            DB_PORT: "${{ secrets.DB_PORT }}"
+            DB_USER_NAME: "${{ secrets.DB_USER_NAME }}"
+            DB_PASSWORD: "${{ secrets.DB_PASSWORD }}"
+            DB_NAME: "${{ secrets.DB_NAME }}"
+            NODE_ENV: "${{ secrets.NODE_ENV }}"
+            USERACCOUNT_INNER: "${{ secrets.USERACCOUNT_INNER }}"
+            AWS_S3_BUCKET: "${{ secrets.AWS_S3_BUCKET }}"
+            AWS_REGION: "${{ secrets.AWS_REGION }}"
+            CLIENT_ORIGIN: "${{ secrets.CLIENT_ORIGIN }}"
+          EOF
+
+      - name: Copy deployment files to EC2
+        run: |
+          scp -o StrictHostKeyChecking=no upload-env.yaml ${{ secrets.EC2_USER }}@${{ secrets.EC2_HOST }}:/home/${{ secrets.EC2_USER }}/
+          scp -o StrictHostKeyChecking=no manifests/upload/deployment.yaml ${{ secrets.EC2_USER }}@${{ secrets.EC2_HOST }}:/home/${{ secrets.EC2_USER }}/
+
+      - name: Deploy to K8s on EC2
+        run: |
+          ssh -o StrictHostKeyChecking=no ${{ secrets.EC2_USER }}@${{ secrets.EC2_HOST }} << 'EOF'
+            kubectl apply -f /home/${{ secrets.EC2_USER }}/upload-env.yaml
+            kubectl apply -f /home/${{ secrets.EC2_USER }}/deployment.yaml
+            kubectl rollout restart deployment upload
+          EOF

--- a/manifests/upload/deployment.yaml
+++ b/manifests/upload/deployment.yaml
@@ -1,0 +1,51 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: upload
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: upload
+  template:
+    metadata:
+      labels:
+        app: upload
+    spec:
+      containers:
+        - name: upload
+          image: gomdadi/upload:latest
+          imagePullPolicy: Always
+          ports:
+            - containerPort: 3000
+            - containerPort: 50055
+          envFrom:
+            - configMapRef:
+                name: upload-env
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: upload-rest
+spec:
+  type: NodePort
+  selector:
+    app: upload
+  ports:
+    - port: 3000
+      targetPort: 3000
+      nodePort: 30355
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: upload-grpc
+spec:
+  type: ClusterIP
+  selector:
+    app: upload
+  ports:
+    - port: 50055
+      targetPort: 50055


### PR DESCRIPTION
Introduce a GitHub Actions workflow to automate deployment of the upload service to EC2. Added Kubernetes manifests for managing deployment, REST, and gRPC services of the upload application. Ensured secure configuration via secrets and automated rollout restart for updates.