### PR TITLE
[Feat] Update web3gateway service to use port 4000 instead of 3000

### DIFF
--- a/manifests/web3gateway/deployment.yaml
+++ b/manifests/web3gateway/deployment.yaml
@@ -17,7 +17,7 @@ spec:
           image: gomdadi/web3gateway:latest
           imagePullPolicy: Always
           ports:
-            - containerPort: 3000
+            - containerPort: 4000
             - containerPort: 50052
           envFrom:
             - configMapRef:
@@ -33,8 +33,8 @@ spec:
   selector:
     app: web3gateway
   ports:
-    - port: 3000
-      targetPort: 3000
+    - port: 4000
+      targetPort: 4000
       nodePort: 30352
 
 ---


### PR DESCRIPTION
Updated the container and service configuration to change the primary port from 3000 to 4000. This ensures proper alignment between the deployment and exposed service ports. Verified the change for compatibility with existing configurations.