### PR TITLE
[Feat] Add CI/CD workflow and Kubernetes manifests for purchase

### DIFF
--- a/.github/workflows/deploy-purchase.yml
+++ b/.github/workflows/deploy-purchase.yml
@@ -1,0 +1,53 @@
+name: Deploy Upload to EC2
+
+on:
+  push:
+    branches:
+      - main
+  repository_dispatch:
+    types: [deploy-purchase]
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Set up SSH key
+        uses: webfactory/ssh-agent@v0.8.0
+        with:
+          ssh-private-key: ${{ secrets.EC2_SSH_KEY }}
+
+      - name: Generate env config file (purchase-env.yaml)
+        run: |
+          cat <<EOF > purchase-env.yaml
+          apiVersion: v1
+          kind: ConfigMap
+          metadata:
+            name: purchase-env
+          data:
+            DB_HOST: "${{ secrets.DB_HOST }}"
+            DB_PORT: "${{ secrets.DB_PORT }}"
+            DB_USER_NAME: "${{ secrets.DB_USER_NAME }}"
+            DB_PASSWORD: "${{ secrets.DB_PASSWORD }}"
+            DB_NAME: "${{ secrets.DB_NAME }}"
+            NODE_ENV: "${{ secrets.NODE_ENV }}"
+            USERACCOUNT_INNER: "${{ secrets.USERACCOUNT_INNER }}"
+            CLIENT_ORIGIN: "${{ secrets.CLIENT_ORIGIN }}"
+            MANAGEMENT_INNER: "${{ secrets.MANAGEMENT_INNER }}"
+          EOF
+
+      - name: Copy deployment files to EC2
+        run: |
+          scp -o StrictHostKeyChecking=no purchase-env.yaml ${{ secrets.EC2_USER }}@${{ secrets.EC2_HOST }}:/home/${{ secrets.EC2_USER }}/
+          scp -o StrictHostKeyChecking=no manifests/purchase/deployment.yaml ${{ secrets.EC2_USER }}@${{ secrets.EC2_HOST }}:/home/${{ secrets.EC2_USER }}/
+
+      - name: Deploy to K8s on EC2
+        run: |
+          ssh -o StrictHostKeyChecking=no ${{ secrets.EC2_USER }}@${{ secrets.EC2_HOST }} << 'EOF'
+            kubectl apply -f /home/${{ secrets.EC2_USER }}/purchase-env.yaml
+            kubectl apply -f /home/${{ secrets.EC2_USER }}/deployment.yaml
+            kubectl rollout restart deployment purchase
+          EOF

--- a/manifests/purchase/deployment.yaml
+++ b/manifests/purchase/deployment.yaml
@@ -1,0 +1,51 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: purchase
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: purchase
+  template:
+    metadata:
+      labels:
+        app: purchase
+    spec:
+      containers:
+        - name: purchase
+          image: gomdadi/purchase:latest
+          imagePullPolicy: Always
+          ports:
+            - containerPort: 3000
+            - containerPort: 50056
+          envFrom:
+            - configMapRef:
+                name: purchase-env
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: purchase-rest
+spec:
+  type: NodePort
+  selector:
+    app: purchase
+  ports:
+    - port: 3000
+      targetPort: 3000
+      nodePort: 30356
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: purchase-grpc
+spec:
+  type: ClusterIP
+  selector:
+    app: purchase
+  ports:
+    - port: 50056
+      targetPort: 50056


### PR DESCRIPTION
This commit introduces a GitHub Actions workflow for deploying the purchase service to an EC2-hosted Kubernetes cluster. It also includes Kubernetes deployment and service manifests for the REST and gRPC endpoints of the purchase service.