### PR TITLE
feat: Rename service port name to 'qdrant' in deployment manifest.

### DIFF
--- a/manifests/qdrant/deployment.yaml
+++ b/manifests/qdrant/deployment.yaml
@@ -36,7 +36,7 @@ spec:
   selector:
     app: qdrant
   ports:
-    - name: http
+    - name: qdrant
       port: 6333
       targetPort: 6333
   type: ClusterIP


### PR DESCRIPTION
Updated the port name from 'http' to 'qdrant' in the Qdrant deployment file. This change aims to improve clarity and better reflect the service's purpose.